### PR TITLE
ActiveRecord Phase #2.1 - Foundational Fixes 🎉

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,45 @@
 
 # Activerecord Aurora Serverless Adapter
 
-<a href="https://github.com/customink/lamby"><img src="https://user-images.githubusercontent.com/2381/59363668-89edeb80-8d03-11e9-9985-2ce14361b7e3.png" alt="Lamby: Simple Rails & AWS Lambda Integration using Rack." align="right" width="300" /></a>**⚠️ WORK IN PROGRESS**<br><br>Simple ActiveRecord MySQL adapter extensions to allow Rails to use [AWS Aurora Serverless](https://aws.amazon.com/rds/aurora/serverless/). Perfect if you are using [Lamby](https://lamby.custominktech.com) to deploy your Rails applications to AWS Lambda.
+<a href="https://github.com/customink/lamby"><img src="https://user-images.githubusercontent.com/2381/59363668-89edeb80-8d03-11e9-9985-2ce14361b7e3.png" alt="Lamby: Simple Rails & AWS Lambda Integration using Rack." align="right" width="300" /></a>**⚠️ WORK IN PROGRESS**<br><br>Simple ActiveRecord Mysql2 adapter extensions to allow Rails to use [AWS Aurora Serverless](https://aws.amazon.com/rds/aurora/serverless/) via the [Aws::RDSDataService::Client](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/RDSDataService/Client.html) internface. Perfect if you are using [Lamby](https://lamby.custominktech.com) to deploy your Rails applications to AWS Lambda.
 
 **[Lamby: Simple Rails & AWS Lambda Integration using Rack.](https://lamby.custominktech.com)**
 
 
 ## Highlights
 
-* Developed and tested with Aurora Serverless MySQL v5.6.
-* Replaces the mysql2 gem requirement with [Aws::RDSDataService::Client](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/RDSDataService/Client.html).
-* Emoji support via `utf8mb4`. Please configure your cluster's parameter group. See our [CDK Stack](https://github.com/customink/activerecord-aurora-serverless-adapter/blob/master/test/aurora-serverless/lib/aurora-serverless-stack.ts) for parameter examples.
+This gem allows Rails to seamless use
 
-Here are some misc gotchas.
+* No need for the `mysql2` gem at all!
+* Developed and tested with Aurora Serverless MySQL v5.6.
+* Emoji support via `utf8mb4`. Please configure your cluster's parameter group. See our [CDK Stack](/blob/master/test/aurora-serverless/lib/aurora-serverless-stack.ts) for examples.
+
+Here are some misc features that work differently for the Mysql2 adapter under Aurora Serverless.
 
 * Multiple schemas are not supported.
 * We assume that all database times are UTC.
 * Prepared statement are not supported.
+* Batch statements are not supported.
+
+
+## Usage
+
+Add the gem to your `Gemfile`. Remember, You **DO NOT** have to add the `mysql2` gem.
+
+```ruby
+gem 'activerecord-aurora-serverless-adapter'
+```
+
+Assuming you have [created your database](/blob/master/test/aurora-serverless/lib/aurora-serverless-stack.ts) with the Data API enabled and [configured your secrets](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html) then configure your `database.yml` file like so.
+
+```yaml
+database: 'mydatabase'
+adapter: aurora_serverless
+secret_arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:Secret-kd2ASwipxeWw-Bdsiww
+resource_arn: arn:aws:rds:us-east-1:123456789012:cluster:mydatabase
+```
+
+**IMPORTANT:** Please do not use any standard Rails or Mysql2 configuration options here. All or ignored or removed. However, please feel free to use any valid [Aws::RDSDataService::Client](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/RDSDataService/Client.html#initialize-instance_method) options here. They will all be passed to the Clients `#initialize` method.
 
 
 ## Contributing
@@ -76,6 +99,7 @@ From here you can run `npm`, `tsc`, `cdk` or whatever commands are needed.
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+
 
 ## Code of Conduct
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,28 @@
 
+## Stats
+
+```
+Finished in 3352.854458s, 2.0069 runs/s, 5.1974 assertions/s.
+6729 runs, 17426 assertions, 88 failures, 72 errors, 20 skips
+```
+
+* (~70) Misc time preisions errors.
+  - TimePrecisionTest#test_formatting_time_according_to_precision
+* (11) ActiveRecord::AdapterNotSpecified: The `foo` database is not configured for the `test` environment.
+  - ConnectionHandlerTest#test_establish_connection_using_2_level_config_defaults_to_default_env_primary_db:
+* (8) Query pattern(s) /BEGIN/i, /COMMIT/i not found.
+  - ConcurrentTransactionTest#test_accessing_raw_connection_disables_lazy_transactions
+* (4) Cannot add or update a child row: a foreign key constraint fails
+  - ConcurrentTransactionTest#test_checking_in_connection_reenables_lazy_transactions
+* (26) ArgumentError: invalid configuration option
+  - :pool, :prepared_statements, :reaping_frequency, :strict, :flags, advisory_locks
+  - PooledConnectionsTest#test_pooled_connection_checkin_two:
+  - ActiveRecord::DatabaseTasksDumpSchemaCacheTest#test_dump_schema_cache:
+
+## Continue After Timeout
+
+There is a `continue_after_timeout` setting which the SDK recommends using on DDL statements. Also there is a Mysql2 client method called `#abandon_results!` which is called during batch (maybe other) places.
+
 ## Configure Connection
 
 In the `connection_adapters/abstract_mysql_adapter.rb:707` make sure we take a look at things like wait timeout, etc.
@@ -35,10 +59,7 @@ Communications link failure (Aws::RDSDataService::Errors::BadRequestException)
 The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
 ```
 
-## Misc ActiveRecord Code/Conditions To Remember
+## Connection Pool
 
-These are things that stuck out to me to circle back to when the full test suite is in better condition.
-
-* `def cacheable_query` - Make sure we are not using prepared statements.
-* `def multi_statements_enabled?(flags)` - Not sure if this should be true or false.
+Read the SDK docs. Thinking we should only have one or maybe just let the pool work at both the ActiveRecord level and the SDK level? Oh, also... check the HTTP Persistence options too!
 

--- a/lib/active_record/connection_adapters/aurora_serverless/mysql2.rb
+++ b/lib/active_record/connection_adapters/aurora_serverless/mysql2.rb
@@ -1,5 +1,5 @@
-require 'active_record/connection_adapters/aurora_serverless/mysql2/client'
 require 'active_record/connection_adapters/aurora_serverless/mysql2/result'
+require 'active_record/connection_adapters/aurora_serverless/mysql2/client'
 require 'active_record/connection_adapters/aurora_serverless/mysql2/connection_handling'
 require 'active_record/connection_adapters/aurora_serverless/gem_hack'
 require 'active_record/connection_adapters/mysql2_adapter'
@@ -8,6 +8,41 @@ module ActiveRecord
   module ConnectionAdapters
     class AuroraServerlessAdapter < Mysql2Adapter
       include AuroraServerless::Abstract
+
+      private
+
+      def connect
+        @connection = ConnectionHandling.aurora_serverless_connection_from_config(@config)
+        configure_connection
+      end
+
+      # Abstract Mysql Adapter
+
+      def translate_exception(exception, message:, sql:, binds:)
+        ActiveRecord::StatementInvalid.new(message, sql: sql, binds: binds)
+      end
+
+      # Database Statements
+
+      def execute_batch(sql, name = nil)
+        execute(sql, name)
+      end
+
+      def multi_statements_enabled?(flags)
+        false
+      end
+
+      def with_multi_statements
+        yield
+      end
+
+      def combine_multi_statements(total_sql)
+        total_sql
+      end
+
+      def max_allowed_packet
+        1048576
+      end
 
     end
   end

--- a/lib/active_record/connection_adapters/aurora_serverless/mysql2/client.rb
+++ b/lib/active_record/connection_adapters/aurora_serverless/mysql2/client.rb
@@ -16,6 +16,7 @@ module ActiveRecord
           end
 
           def query(sql)
+            raise ActiveRecord::StatementInvalid if @closed
             AuroraServerless::Mysql2::Result.new execute_statement(sql)
           end
 
@@ -28,7 +29,7 @@ module ActiveRecord
           end
 
           def close
-            nil
+            @closed = true
           end
 
           def automatic_close=(*)
@@ -43,6 +44,7 @@ module ActiveRecord
           end
 
           def ping
+            return false if @closed
             query('SELECT 1').to_a.first.first == 1
           rescue
             false

--- a/lib/active_record/connection_adapters/aurora_serverless/mysql2/connection_handling.rb
+++ b/lib/active_record/connection_adapters/aurora_serverless/mysql2/connection_handling.rb
@@ -2,15 +2,20 @@ module ActiveRecord
   module ConnectionHandling
 
     def aurora_serverless_connection(config)
+      client = aurora_serverless_connection_from_config(config)
+      ConnectionAdapters::AuroraServerlessAdapter.new(client, logger, nil, config)
+    end
+
+    def aurora_serverless_connection_from_config(config)
       options = config.except :adapter, :database, :secret_arn, :resource_arn
-      client = ConnectionAdapters::AuroraServerless::Client.new(
+      ConnectionAdapters::AuroraServerless::Client.new(
         config[:database],
         config[:resource_arn],
         config[:secret_arn],
         options
       )
-      ConnectionAdapters::AuroraServerlessAdapter.new(client, logger, nil, config)
     end
+    module_function :aurora_serverless_connection_from_config
 
   end
 end

--- a/lib/active_record/connection_adapters/aurora_serverless/mysql2/result.rb
+++ b/lib/active_record/connection_adapters/aurora_serverless/mysql2/result.rb
@@ -118,6 +118,7 @@ module ActiveRecord
             'LONGBLOB'   => :blob_value,
             'LONGTEXT'   => :string_value,
           }.freeze
+          private_constant :VALUE_METHODS
 
         end
       end

--- a/lib/mysql2.rb
+++ b/lib/mysql2.rb
@@ -1,1 +1,4 @@
 # This is here so the Mysql2 gem require will no-op.
+#
+module Mysql2
+end

--- a/test/aasa_helper.rb
+++ b/test/aasa_helper.rb
@@ -5,6 +5,7 @@ Dotenv.load('.env')
 require 'minitest/spec'
 require 'minitest/autorun'
 require 'cases/helper' unless ENV['TEST_FILES']
+Rails.backtrace_cleaner.remove_silencers! if ENV['REMOVE_SILENCERS']
 
 module ActiveRecord
   module ConnectionAdapters
@@ -42,6 +43,8 @@ module ActiveRecord
 
         MYSQL_CREATE_TABLE_SQL = %[
           CREATE TABLE IF NOT EXISTS aurora_test (
+            id int NOT NULL AUTO_INCREMENT,
+            PRIMARY KEY (id),
             null_test VARCHAR(10),
             bit_test BIT,
             tiny_int_test TINYINT,

--- a/test/cases/aasa/mysql_client_test.rb
+++ b/test/cases/aasa/mysql_client_test.rb
@@ -44,6 +44,13 @@ module ActiveRecord
           expect(client.affected_rows).must_equal 3
         end
 
+        it '#last_id' do
+          execute "INSERT INTO aurora_test (int_test) VALUES (1)"
+          expect(client.last_id).must_equal 2
+          execute "INSERT INTO aurora_test (int_test) VALUES (1)"
+          expect(client.last_id).must_equal 3
+        end
+
       end
     end
   end


### PR DESCRIPTION
## BEFORE/AFTER

Till we get to 100% green tests, here are the before & current test suite stats. YUP! Lot of wins for a few key pressure point fixes. This to me just shows that the patterns we have for the adapter's delegation to our facade objects are working really well since we went from `~5100` errors to `~100` 🎉

```
Finished in 493.196125s, 13.6437 runs/s, 6.7052 assertions/s.
6729 runs, 3307 assertions, 21 failures, 5075 errors, 11 skips
```

```
Finished in 3352.854458s, 2.0069 runs/s, 5.1974 assertions/s.
6729 runs, 17426 assertions, 88 failures, 72 errors, 20 skips
```

## Connection Handling

This is where most of the work happned for this pull request.

ActiveRecord default `translate_exception` adapter method assumes that `RuntimeError` will not fall thru to the catch all `StatementInvalid`. This is kind of sad since all `Aws::RDSDataService::Errors::ServiceError` inherit from `RuntimeError`. In a latter commit we will fully translate all exceptions but we had to completly override the abstract adapters so any RDS client error is wrapped in ActiveRecord's `StatementInvalid`.

* Return `@connection.last_id` for inserts.
* Implement `RDSDataService::Client` client option sanitization.
* Disconnect state and raising and `ActiveRecord::StatementInvalid`.
* Ensure `@connection.ping` returns false if connection closed.
* Adapter instance `#connect` works and shares new client from `@config`.
* Disable all batch or multiple statement support.

## Mysql2 Namespace

There are a handful of places in the Mysql2 Adapter that call `Mysql2::` objects or constant avalues. Most notable were the adapter's batch insert support methods. Thanks to work done above we got most of these automatically, however, just calling out this work/qa is now done too.

## Documentation

Totally added some more.
